### PR TITLE
Fixed bug causing "Greenhouse" text in dropdown menu to be off center.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -142,7 +142,7 @@ nav a {
 
 .dropdown-content a {
     color: black;
-    padding: 12px 16px;
+    padding: 12px 0px;
     text-decoration: none;
     display: block;
     background-color: darkcyan;


### PR DESCRIPTION
In the projects drop down menu the text in the box for "Greenhouse" appeared off center due to padding. Very nice website overall but this small problem was causing me a great amount of distress. 